### PR TITLE
Support secure uploads 

### DIFF
--- a/migro/cli.py
+++ b/migro/cli.py
@@ -79,6 +79,13 @@ public_key_arg = click.argument(
     type=str,
     is_eager=True)
 
+secret_key_option = click.option(
+    '--secret_key',
+    default=settings.SECRET_KEY,
+    show_default=True,
+    help='Your Uploadcare project secret key, required for secure uploads.',
+    type=str)
+
 upload_base_option = click.option(
     '--upload_base',
     default=settings.UPLOAD_BASE,
@@ -128,12 +135,13 @@ output_file_option = click.option(
 @help_option
 @public_key_arg
 @input_file_arg
+@secret_key_option
 @output_file_option
 @upload_base_option
 @from_url_timeout_option
 @max_concurrent_upload_option
 @status_check_interval_option
-def cli(public_key, input_file, output_file, upload_base, from_url_timeout,
+def cli(public_key, input_file, secret_key, output_file, upload_base, from_url_timeout,
         max_uploads, check_interval):
     """Migrate your files to Uploadcare."""
     # Set settings from the cli args.
@@ -142,6 +150,7 @@ def cli(public_key, input_file, output_file, upload_base, from_url_timeout,
     settings.FROM_URL_TIMEOUT = from_url_timeout
     settings.MAX_CONCURRENT_UPLOADS = max_uploads
     settings.STATUS_CHECK_INTERVAL = check_interval
+    settings.SECRET_KEY = secret_key
 
     with open(input_file, 'r') as f:
         urls = f.readlines()

--- a/migro/settings.py
+++ b/migro/settings.py
@@ -12,6 +12,9 @@ UPLOAD_BASE = 'https://upload.uploadcare.com/'
 # Project public key.
 PUBLIC_KEY = None
 
+# Project secret key
+SECRET_KEY = None
+
 # Timeout for status check of file uploaded by `from_url`.
 # If you have big files - you can increase this option.
 FROM_URL_TIMEOUT = 30

--- a/migro/uploader/utils.py
+++ b/migro/uploader/utils.py
@@ -8,6 +8,10 @@
 """
 from asyncio import get_event_loop
 from urllib.parse import urljoin
+from datetime import datetime, timedelta
+import time
+import hashlib
+import hmac
 
 from aiohttp import ClientSession, TCPConnector
 
@@ -32,6 +36,42 @@ async def request(path, params=None):
     params['pub_key'] = settings.PUBLIC_KEY
     params['UPLOADCARE_PUB_KEY'] = settings.PUBLIC_KEY
 
+    if (settings.SECRET_KEY):
+        expire_timestamp = generate_expire_timestamp()
+        upload_signature = generate_secure_signature(settings.SECRET_KEY, expire_timestamp)
+
+        params['signature'] =  upload_signature
+        params['expire'] = expire_timestamp
+
     response = await session.request(
         method='get', url=url, allow_redirects=True, params=params)
     return response
+
+
+def generate_expire_timestamp(minutes_ahead=5):
+    """Generate expiration timestamp for specified minutes after current time.
+
+    :param minutes_ahead: Minutes after current time.
+
+    :return: int.
+
+    """
+    expire_timestamp = int(time.time()) + 60 * minutes_ahead
+
+    return expire_timestamp
+
+
+def generate_secure_signature(secret, expire):
+    """Generate secure signature with specified secret and expiration timestamp.
+
+    :param secret: Secret Key.
+    :param expire: Expiration timestamp.
+
+    :return: str.
+
+    """
+    k, m = secret, str(expire).encode('utf-8')
+    if not isinstance(k, (bytes, bytearray)):
+        k = k.encode('utf-8')
+
+    return hmac.new(k, m, hashlib.sha256).hexdigest()

--- a/migro/uploader/utils.py
+++ b/migro/uploader/utils.py
@@ -6,12 +6,15 @@
     Helpers functions.
 
 """
-from asyncio import get_event_loop
-from urllib.parse import urljoin
-from datetime import datetime, timedelta
-import time
 import hashlib
 import hmac
+import time
+
+from aiohttp import ClientSession, TCPConnector
+from asyncio import get_event_loop
+from urllib.parse import urljoin
+
+from migro import settings
 
 from aiohttp import ClientSession, TCPConnector
 


### PR DESCRIPTION
## Description
Support secure uploads. Add --secret_key option.

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

Add --secret_key option to cli. When this option is defined, migro will generate an upload signature for each upload.

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [x] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
