### PR TITLE
Support python version 3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	pytest tests/

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import pytest
+
+from migro.uploader import utils
+from migro.uploader.utils import session
+
+
+class MockResponse:
+    def __init__(self, json, status):
+        self._json = json
+        self.status = status
+
+    async def json(self):
+        return self._json
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+
+class Session:
+    def __init__(self, response):
+        self._response = response
+
+    async def request(self, *args, **kwargs):
+        return self._response
+
+
+@pytest.fixture
+def mock_session():
+    original_session = utils.session
+
+    fake_response = MockResponse(
+        json={
+            'token': 'token',
+            'status': 'success',
+            'uuid': 'file-uuid',
+        },
+        status=200,
+    )
+    utils.session = Session(fake_response)
+
+    yield
+
+    utils.session = original_session
+
+
+@pytest.fixture(scope='session', autouse=True)
+def close_session():
+    asyncio.ensure_future(session.close())

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,28 @@
+from migro.uploader.utils import loop
+from migro.uploader.worker import Uploader, Events
+
+
+def test_uploader(mock_session):
+    successful = []
+    failed = []
+
+    uploader = Uploader(loop=loop)
+
+    uploader.on(
+        Events.UPLOAD_ERROR,
+        Events.DOWNLOAD_ERROR,
+        callback=lambda event: failed.append(event['file']),
+    )
+
+    uploader.on(
+        Events.DOWNLOAD_COMPLETE,
+        callback=lambda event: successful.append(event['file']),
+    )
+
+    urls = ['http://file-url']
+    loop.run_until_complete(uploader.process(urls))
+
+    uploader.shutdown()
+
+    assert successful
+    assert not failed

--- a/workflows/test.yml
+++ b/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.10]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install -r requirements_test.txt
+    - name: Run tests
+      run: make test

--- a/workflows/test.yml
+++ b/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.10]
+        python-version: [3.5, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Workaround to support both python 3.10 and older versions since `loop` parameter is removed from some top-level asyncio functions and primitives.
